### PR TITLE
Increase max shards for nf-test on CI runners

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           NFT_VER: ${{ env.NFT_VER }}
         with:
-          max_shards: 7
+          max_shards: 10
 
       - name: debug
         run: |

--- a/tests/default.nf.test
+++ b/tests/default.nf.test
@@ -104,8 +104,7 @@ nextflow_pipeline {
         }
     }
     */
-    /*
-    // removed in CI because "No splace left on disk" error encountered
+
     test("-profile test_accessions_only") {
         tag "test_accessions_only"
 
@@ -165,7 +164,6 @@ nextflow_pipeline {
             )
         }
     }
-    */
 
     test("-profile test_one_accession_low_gene_count") {
         tag "test_one_accession_low_gene_count"
@@ -192,8 +190,7 @@ nextflow_pipeline {
             )
         }
     }
-    /*
-    // removed in CI because "No splace left on disk" error encountered
+
     test("-profile test_skip_id_mapping") {
         tag "test_skip_id_mapping"
 
@@ -219,7 +216,6 @@ nextflow_pipeline {
             )
         }
     }
-    */
 
     test("-profile test_dataset_custom_mapping_and_gene_length") {
         tag "test_dataset_custom_mapping_and_gene_length"


### PR DESCRIPTION
- uncommented tests that were commented to avoid "No disk space left on device" errors in CI runners
- increased nb of shards for nf-test CI workflow